### PR TITLE
Add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+### Summary
+_Please include a summary of the changes and the related issue._
+
+### Details
+_Add more context to describe the changes..._
+
+### Type of change
+What type of changes does your code introduce. Put an `x` in the boxes that apply
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
+### Checks
+Put an `x` in the boxes that apply. You can also fill these out after creating the PR. They act as a reminder to the code reviewer of what they are going to look for before merging your code.
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] Any dependent changes have been merged and published in downstream modules
+
+### Screenshots
+_If appropriate..._


### PR DESCRIPTION
### Summary
Add pull request template to the project.

### Details
* Add new file for `pull_request_template.md`

### References
- [GitHub PR Templates](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository)